### PR TITLE
Fix meta

### DIFF
--- a/pixel.xml
+++ b/pixel.xml
@@ -172,7 +172,7 @@ license:		PLEASE DO NOT MODIFY or use graphics in other projects.
 		</textlist>
 		
 <!--         Start Meta Data                  -->	
-		<text name="md_lbl_rating, md_lbl_releasedate, md_lbl_players, md_players, md_lbl_developer, md_developer, md_lbl_publisher, md_publisher, md_lbl_genre, md_genre, md_lbl_players, md_players, md_lbl_playcount, md_playcount, md_lbl_lastplayed, md_description">
+		<text name="md_lbl_rating, md_lbl_releasedate, md_releasedate, md_lbl_players, md_players, md_lbl_developer, md_developer, md_lbl_publisher, md_publisher, md_lbl_genre, md_genre, md_lbl_players, md_players, md_lbl_playcount, md_playcount, md_lbl_lastplayed, md_lastplayed, md_description">
 			<pos>1 1</pos>
 			<size>0.192 0.030</size>
 			<color>ffffff</color>

--- a/ports/theme.xml
+++ b/ports/theme.xml
@@ -68,6 +68,7 @@
 			<pos>1 1</pos>
 		</text>	
 
+<!--
 		<text name="md_description">
 			<color>ffffff</color>
 			<pos>0.569 0.677</pos>
@@ -77,7 +78,7 @@
 			<alignment>center</alignment>
 			<fontSize>0.03</fontSize>
 		</text>
-
+-->
 
 	</view>
 	


### PR DESCRIPTION
`md_releasedate` and `md_lastplayed` were not included in this `<text>` block, so they had no `<size>` parameter causing them to wrap too early, overlapping with other text:

![20220629_104333](https://user-images.githubusercontent.com/92833764/176510009-0e4aefbd-4513-4d01-97ec-7a38b8a21332.png)

Adding these two values to the `<text>` block gives them a proper width and allows them to display correctly:

![20220629_112842](https://user-images.githubusercontent.com/92833764/176510261-f5b15a8c-4e46-4504-b899-baa790dda0a2.png)

I also commented out the `md_description` section in `./ports/theme.xml`; the description used in the "ports" menu had different geometry than the rest of the systems. Was this on purpose? The difference was slight but jarring, while flipping between systems. It looks better (to me) and still seems to work fine, without it:

View in other systems:

![20220629_113613](https://user-images.githubusercontent.com/92833764/176511390-c100c391-5c88-41b4-81ca-ebdfbb7ca014.png)

View in "ports" (before fix):

![20220629_113620](https://user-images.githubusercontent.com/92833764/176511502-9edeaea2-80c1-45f5-9430-b0edb336bcd5.png)

View in "ports" (after fix):

![20220629_113654](https://user-images.githubusercontent.com/92833764/176511585-9a2940f7-11cd-4583-8a4b-d14617399bac.png)

